### PR TITLE
Remove libcrypto from openssl

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -88,6 +88,7 @@ RUN rm -f \
   libbbox* \
   libboost_* \
   libcapture* \
+  libcrypto* \
   libfcgi* \
   libicu* \
   libjpeg* \
@@ -133,6 +134,7 @@ RUN rm -rf \
   fcgi* \
   gdk-pixbuf-* \
   icu* \
+  libcrypto.pc \
   libprotobuf-c.pc \
   libscene.pc \
   libssl.pc \

--- a/Dockerfile.armv7hf
+++ b/Dockerfile.armv7hf
@@ -88,6 +88,7 @@ RUN rm -f \
   libbbox* \
   libboost_* \
   libcapture* \
+  libcrypto* \
   libfcgi* \
   libicu* \
   libjpeg* \
@@ -133,6 +134,7 @@ RUN rm -rf \
   fcgi* \
   gdk-pixbuf-* \
   icu* \
+  libcrypto.pc \
   libprotobuf-c.pc \
   libscene.pc \
   libssl.pc \


### PR DESCRIPTION
This library is also part of the openssl package.

Reference: ECODEVT-170

### Checklist before requesting a review

- [x ] I have performed a self-review of my own code
- [-] I have verified that the code builds perfectly fine on my local system
- [-] I have added tests that prove my fix is effective or that my feature works
- [-] I have commented my code, particularly in hard-to-understand areas
- [x ] I have verified that my code follows the style already available in the repository
- [-] I have made corresponding changes to the documentation
