### PR TITLE
Remove libcrypto from openssl

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -88,6 +88,7 @@ RUN rm -f \
   libbbox* \
   libboost_* \
   libcapture* \
+  libcrypto* \
   libfcgi* \
   libicu* \
   libjpeg* \
@@ -133,6 +134,7 @@ RUN rm -rf \
   fcgi* \
   gdk-pixbuf-* \
   icu* \
+  libcrypto.pc \
   libprotobuf-c.pc \
   libscene.pc \
   libssl.pc \

--- a/Dockerfile.armv7hf
+++ b/Dockerfile.armv7hf
@@ -88,6 +88,7 @@ RUN rm -f \
   libbbox* \
   libboost_* \
   libcapture* \
+  libcrypto* \
   libfcgi* \
   libicu* \
   libjpeg* \
@@ -133,6 +134,7 @@ RUN rm -rf \
   fcgi* \
   gdk-pixbuf-* \
   icu* \
+  libcrypto.pc \
   libprotobuf-c.pc \
   libscene.pc \
   libssl.pc \


### PR DESCRIPTION
This library is also part of the openssl package.

Reference: ECODEVT-170