### PR TITLE
Revert "Remove libcrypto from openssl"

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -88,7 +88,6 @@ RUN rm -f \
   libbbox* \
   libboost_* \
   libcapture* \
-  libcrypto* \
   libfcgi* \
   libicu* \
   libjpeg* \
@@ -134,7 +133,6 @@ RUN rm -rf \
   fcgi* \
   gdk-pixbuf-* \
   icu* \
-  libcrypto.pc \
   libprotobuf-c.pc \
   libscene.pc \
   libssl.pc \

--- a/Dockerfile.armv7hf
+++ b/Dockerfile.armv7hf
@@ -88,7 +88,6 @@ RUN rm -f \
   libbbox* \
   libboost_* \
   libcapture* \
-  libcrypto* \
   libfcgi* \
   libicu* \
   libjpeg* \
@@ -134,7 +133,6 @@ RUN rm -rf \
   fcgi* \
   gdk-pixbuf-* \
   icu* \
-  libcrypto.pc \
   libprotobuf-c.pc \
   libscene.pc \
   libssl.pc \


### PR DESCRIPTION
The library libcrypto is needed by the licensekey API.
This reverts commit ce7a6284595a5294e71ad6e1fdd8c29c350c48fc.

Reference: ECODEVT-170