### PR TITLE
Remove files for libevent

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -166,6 +166,7 @@ RUN rm -rf \
   axsdk/axptz* \
   capture* \
   dbus-* \
+  event.h \
   gcrypt.h \
   gmock \
   gmp-32.h \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -91,6 +91,7 @@ RUN rm -f \
   libaxptz* \
   libboost_* \
   libcapture* \
+  libevent.so* \
   libgcrypt* \
   libgmp* \
   libgnutls* \

--- a/Dockerfile.armv7hf
+++ b/Dockerfile.armv7hf
@@ -90,6 +90,7 @@ RUN rm -f \
   libaxhttp* \
   libaxptz* \
   libboost_* \
+  libevent.so* \
   libcapture* \
   libgcrypt* \
   libgmp* \

--- a/Dockerfile.armv7hf
+++ b/Dockerfile.armv7hf
@@ -166,6 +166,7 @@ RUN rm -rf \
   axsdk/axptz* \
   capture* \
   dbus-* \
+  event.h \
   gcrypt.h \
   gmock \
   gmp-32.h \


### PR DESCRIPTION
### Describe your changes

Remove files related to libevent from SDK. Note, this is not related to the files for the [Axevent API](https://axiscommunications.github.io/acap-documentation/docs/api/native-sdk-api.html#event-api).

### Issue ticket number and link

AFT-732

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
