### PR TITLE
Test/time bits 32

### DIFF
--- a/Dockerfile.armv7hf
+++ b/Dockerfile.armv7hf
@@ -47,7 +47,7 @@ RUN sed -i 's#export PATH=#export PATH=/opt/axis/acapsdk/axis-acap-manifest-tool
 # Update paths and add explicit sdk path to linker in environment-setup script
 # Add the --disable-new-dtags parameter to the default LDFLAGS to solve dynamic library rpath issues
 RUN sed -i 's:/opt/axis/sdk:/opt/axis/acapsdk:g' /opt/axis/acapsdk/environment-setup* && \
-  sed -i '/\(CC\|CPP\|CXX\)=/s:"$: -L$SDKTARGETSYSROOT/usr/lib":g' /opt/axis/acapsdk/environment-setup* && \
+  sed -i '/\(CC\|CPP\|CXX\)=/s:"$: -L$SDKTARGETSYSROOT/usr/lib -D_TIME_BITS=32 -D_FILE_OFFSET_BITS=32":g' /opt/axis/acapsdk/environment-setup* && \
   sed -i '/^export LDFLAGS=/ s:"$: -Wl,--disable-new-dtags":' /opt/axis/acapsdk/environment-setup*
 
 # Copy the lib, include and .pc files from the API container

--- a/Dockerfile.armv7hf
+++ b/Dockerfile.armv7hf
@@ -47,7 +47,9 @@ RUN sed -i 's#export PATH=#export PATH=/opt/axis/acapsdk/axis-acap-manifest-tool
 # Update paths and add explicit sdk path to linker in environment-setup script
 # Add the --disable-new-dtags parameter to the default LDFLAGS to solve dynamic library rpath issues
 RUN sed -i 's:/opt/axis/sdk:/opt/axis/acapsdk:g' /opt/axis/acapsdk/environment-setup* && \
-  sed -i '/\(CC\|CPP\|CXX\)=/s:"$: -L$SDKTARGETSYSROOT/usr/lib -D_TIME_BITS=32 -D_FILE_OFFSET_BITS=32":g' /opt/axis/acapsdk/environment-setup* && \
+  sed -i '/\(CC\|CPP\|CXX\)=/s:"$: -L$SDKTARGETSYSROOT/usr/lib":g' /opt/axis/acapsdk/environment-setup* && \
+  sed -i '/\(CC\|CPP\|CXX\)=/s:"$: -D_TIME_BITS=32":g' /opt/axis/acapsdk/environment-setup* && \
+  sed -i '/\(CC\|CPP\|CXX\)=/s:"$: -D_FILE_OFFSET_BITS=32":g' /opt/axis/acapsdk/environment-setup* && \
   sed -i '/^export LDFLAGS=/ s:"$: -Wl,--disable-new-dtags":' /opt/axis/acapsdk/environment-setup*
 
 # Copy the lib, include and .pc files from the API container


### PR DESCRIPTION
### Describe your changes

The SDK was incorrectly building with 64-bit time and file offset types for armv7hf, potentially causing runtime issues and unexpected behavior on 32-bit hardware.
 
Solution forces all time and file offset types to properly use 32-bit, matching the actual architecture capabilities.

### Issue ticket number and link

ECODEVT-1376

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
