### PR TITLE
Set default workflow token permissions to read-only

### DIFF
--- a/.github/workflows/build-dockerfile.yml
+++ b/.github/workflows/build-dockerfile.yml
@@ -4,6 +4,9 @@ on:
     paths:
       - 'Dockerfile*'
       - '.github/workflows/build-dockerfile.yml'
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Token-Permissions** remedy.

It sets the default workflow token to read-only by adding a top-level `permissions` block to workflows that lacked one:

- `.github/workflows/build-dockerfile.yml`

Any job that needs more than read access must be granted those permissions at the job level, otherwise it may fail.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#token-permissions) for details.